### PR TITLE
setTempo parameter in bpm

### DIFF
--- a/src/midi-writer-js.js
+++ b/src/midi-writer-js.js
@@ -79,9 +79,10 @@
 	};
 
 
-	MidiWriter.Track.prototype.setTempo = function(tempo) {
+	MidiWriter.Track.prototype.setTempo = function(bpm) {
 		var event = new MidiWriter.MetaEvent({data: [MidiWriter.constants.META_TEMPO_ID]});
 		event.data.push(0x03); // Size
+		var tempo = 60000000 / bpm;
 		event.data = event.data.concat(MidiWriter.numberToBytes(tempo, 3)); // Tempo, 3 bytes
 		this.addEvent(event);
 	};


### PR DESCRIPTION
Actually Track.setTempo must be specified in microseconds per quarter note, this commit change the parameter to bpm.

see  #10

Before:
`track.setTempo(500000); // equals 120 bpm`
After:
`track.setTempo(120); // converts to 500000 microseconds per quarter note`