### PR TITLE
Allow notes of zero length

### DIFF
--- a/src/midi-writer-js.js
+++ b/src/midi-writer-js.js
@@ -362,8 +362,8 @@
 	MidiWriter.NoteEvent.prototype.getDurationMultiplier = function(duration, type) {
 		// Need to apply duration here.  Quarter note == MidiWriter.HEADER_CHUNK_DIVISION
 		switch (duration) {
-      case '0':
-        return 0;
+			case '0':
+				return 0;
 			case '1':
 				return 4;
 			case '2':

--- a/src/midi-writer-js.js
+++ b/src/midi-writer-js.js
@@ -362,6 +362,8 @@
 	MidiWriter.NoteEvent.prototype.getDurationMultiplier = function(duration, type) {
 		// Need to apply duration here.  Quarter note == MidiWriter.HEADER_CHUNK_DIVISION
 		switch (duration) {
+      case '0':
+        return 0;
 			case '1':
 				return 4;
 			case '2':


### PR DESCRIPTION
The use case being if I want to add just a rest, without necessitating a following note (as the current implementation of wait implies). A duration of 0 and non-zero wait should now allow this.

