### PR TITLE
Added missing enharmomic equivalents

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -27,7 +27,7 @@ var Constants = {
 
 (function() {
 	// Builds notes object for reference against binary values.
-	var allNotes = [['C'], ['C#','Db'], ['D'], ['D#','Eb'], ['E'],['F'], ['F#','Gb'], ['G'], ['G#','Ab'], ['A'], ['A#','Bb'], ['B']];
+	var allNotes = [['C','B#'], ['C#','Db'], ['D'], ['D#','Eb'], ['E','Fb'],['F','E#'], ['F#','Gb'], ['G'], ['G#','Ab'], ['A'], ['A#','Bb'], ['B','Cb']];
 	var counter = 0;
 
 	// All available octaves.


### PR DESCRIPTION
`C`, `E`, `F` and `B` are missing their enharmonic equivalents. This causes problems when doing the following:

    track.addEvent(new MidiWriter.NoteEvent({
      pitch: [ 'Eb4', 'Ab4', 'Cb5' ]
    }));

... as no `Cb` constant is defined.