### PR TITLE
bugfix: if startTick = 0, note events weren't handled correctly

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -61,7 +61,7 @@ class Track {
 				}
 
 				// If this note event has an explicit startTick then we need to set aside for now
-				if (event.startTick) {
+				if (typeof event.startTick !== 'undefined') {
 					this.explicitTickEvents.push(event);
 
 				} else {


### PR DESCRIPTION
I like the work you're doing with startTick -- that will make what I'm hoping to do a LOT easier.

I tried to set up 4 sixteenth notes on the fours:

```
var track = new MidiWriter.Track();
var notes = [
    new MidiWriter.NoteEvent({pitch:['G#1'], velocity: 90, startTick: 0,   duration: 'T32'}),
    new MidiWriter.NoteEvent({pitch:['G#1'], velocity: 90, startTick: 128, duration: 'T32'}),
    new MidiWriter.NoteEvent({pitch:['G#1'], velocity: 90, startTick: 256, duration: 'T32'}),
    new MidiWriter.NoteEvent({pitch:['G#1'], velocity: 90, startTick: 384, duration: 'T32'}),
];
for (var i = 0; i < notes.length; i++)
{
    track.addEvent(notes[i]);
}
```

The second note came in immediately after the first sixteenth note.  The change I made in the pull request fixes this problem.