### PR TITLE
Revert "bugfix: if startTick = 0, note events weren't handled correctly"

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -65,7 +65,7 @@ class Track {
 				}
 
 				// If this note event has an explicit startTick then we need to set aside for now
-				if (typeof event.startTick !== 'undefined') {
+				if (event.startTick) {
 					this.explicitTickEvents.push(event);
 
 				} else {


### PR DESCRIPTION
Actually noticing some side effects of this with events not using `startTick`, reverting for now
Reverts grimmdude/MidiWriterJS#45