### PR TITLE
fixed the handling of startTick = 0

### DIFF
--- a/src/note-events/note-event.js
+++ b/src/note-events/note-event.js
@@ -20,7 +20,8 @@ class NoteEvent {
 		this.channel 	= fields.channel || 1;
 		this.repeat 	= fields.repeat || 1;
 		this.grace		= fields.grace;
-		this.startTick	= fields.startTick || null;
+		this.startTick	= (typeof fields.startTick !== 'undefined')
+                           ? fields.startTick : null;
 		this.tickDuration = Utils.getTickDuration(this.duration);
 		this.restDuration = Utils.getTickDuration(this.wait);
 


### PR DESCRIPTION
Congrats on 1.7.0!  I found a little bug with notes where startTick = 0.  When they are created, the startTick is set to null, so they are treated by the track as being sequential instead of explicit.