### PR TITLE
add .editorconfig , eslint and fixes simple lint issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+insert_final_newline = false
+indent_size = 2
+indent_style = space
+
+[*.md]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+**/__tests__/**
+**/coverage/**
+**/node_modules/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,318 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "rules": {
+        "accessor-pairs": "error",
+        "array-bracket-newline": "error",
+        "array-bracket-spacing": [
+            "error",
+            "never"
+        ],
+        "array-callback-return": "error",
+        "array-element-newline": "off",
+        "arrow-body-style": "off",
+        "arrow-parens": "off",
+        "arrow-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": true
+            }
+        ],
+        "block-scoped-var": "off",
+        "block-spacing": "off",
+        "brace-style": [
+            "error",
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
+        ],
+        "callback-return": "error",
+        "camelcase": "error",
+        "capitalized-comments": "off",
+        "class-methods-use-this": "off",
+        "comma-dangle": "off",
+        "comma-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "comma-style": [
+            "error",
+            "last"
+        ],
+        "complexity": "error",
+        "computed-property-spacing": [
+            "error",
+            "never"
+        ],
+        "consistent-return": "error",
+        "consistent-this": "error",
+        "curly": "off",
+        "default-case": "off",
+        "dot-location": [
+            "error",
+            "property"
+        ],
+        "dot-notation": "error",
+        "eol-last": "off",
+        "eqeqeq": "off",
+        "func-call-spacing": "error",
+        "func-name-matching": "error",
+        "func-names": "off",
+        "func-style": "error",
+        "function-paren-newline": "error",
+        "generator-star-spacing": "error",
+        "global-require": "off",
+        "guard-for-in": "off",
+        "handle-callback-err": "error",
+        "id-blacklist": "error",
+        "id-length": "off",
+        "id-match": "error",
+        "implicit-arrow-linebreak": [
+            "error",
+            "beside"
+        ],
+        "indent": "off",
+        "indent-legacy": "off",
+        "init-declarations": "off",
+        "jsx-quotes": "error",
+        "key-spacing": "off",
+        "keyword-spacing": "off",
+        "line-comment-position": "off",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "lines-around-comment": "error",
+        "lines-around-directive": "error",
+        "lines-between-class-members": [
+            "error",
+            "always"
+        ],
+        "max-classes-per-file": "error",
+        "max-depth": "off",
+        "max-len": "off",
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "max-nested-callbacks": "error",
+        "max-params": "off",
+        "max-statements": "off",
+        "max-statements-per-line": "error",
+        "multiline-comment-style": [
+            "error",
+            "separate-lines"
+        ],
+        "new-cap": "error",
+        "new-parens": "error",
+        "newline-after-var": "off",
+        "newline-before-return": "off",
+        "newline-per-chained-call": "error",
+        "no-alert": "error",
+        "no-array-constructor": "error",
+        "no-async-promise-executor": "error",
+        "no-await-in-loop": "error",
+        "no-bitwise": "off",
+        "no-buffer-constructor": "off",
+        "no-caller": "error",
+        "no-catch-shadow": "error",
+        "no-confusing-arrow": "error",
+        "no-constant-condition": [
+            "error",
+            {
+                "checkLoops": false
+            }
+        ],
+        "no-continue": "error",
+        "no-div-regex": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "error",
+        "no-empty-function": "error",
+        "no-eq-null": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-extra-parens": "off",
+        "no-floating-decimal": "error",
+        "no-implicit-coercion": "error",
+        "no-implicit-globals": "error",
+        "no-implied-eval": "error",
+        "no-inline-comments": "off",
+        "no-inner-declarations": [
+            "error",
+            "functions"
+        ],
+        "no-invalid-this": "error",
+        "no-iterator": "error",
+        "no-label-var": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "error",
+        "no-loop-func": "off",
+        "no-magic-numbers": "off",
+        "no-misleading-character-class": "error",
+        "no-mixed-operators": [
+            "error",
+            {
+                "allowSamePrecedence": true
+            }
+        ],
+        "no-mixed-requires": "error",
+        "no-multi-assign": "error",
+        "no-multi-spaces": "error",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": "error",
+        "no-native-reassign": "error",
+        "no-negated-condition": "off",
+        "no-negated-in-lhs": "error",
+        "no-nested-ternary": "error",
+        "no-new": "error",
+        "no-new-func": "error",
+        "no-new-object": "error",
+        "no-new-require": "error",
+        "no-new-wrappers": "error",
+        "no-octal-escape": "error",
+        "no-param-reassign": "off",
+        "no-path-concat": "error",
+        "no-plusplus": [
+            "error",
+            {
+                "allowForLoopAfterthoughts": true
+            }
+        ],
+        "no-process-env": "error",
+        "no-process-exit": "error",
+        "no-proto": "error",
+        "no-prototype-builtins": "error",
+        "no-restricted-globals": "error",
+        "no-restricted-imports": "error",
+        "no-restricted-modules": "error",
+        "no-restricted-properties": "error",
+        "no-restricted-syntax": "error",
+        "no-return-assign": "off",
+        "no-return-await": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-shadow": "error",
+        "no-shadow-restricted-names": "error",
+        "no-spaced-func": "error",
+        "no-sync": "error",
+        "no-tabs": "off",
+        "no-template-curly-in-string": "error",
+        "no-ternary": "off",
+        "no-throw-literal": "off",
+        "no-trailing-spaces": "off",
+        "no-undef-init": "error",
+        "no-undefined": "error",
+        "no-underscore-dangle": "off",
+        "no-unmodified-loop-condition": "error",
+        "no-unneeded-ternary": "error",
+        "no-unused-expressions": "error",
+        "no-use-before-define": "error",
+        "no-useless-call": "error",
+        "no-useless-catch": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "error",
+        "no-useless-constructor": "off",
+        "no-useless-rename": "error",
+        "no-useless-return": "error",
+        "no-var": "off",
+        "no-void": "error",
+        "no-warning-comments": "error",
+        "no-whitespace-before-property": "error",
+        "no-with": "error",
+        "nonblock-statement-body-position": "error",
+        "object-curly-newline": "error",
+        "object-curly-spacing": [
+            "error",
+            "never"
+        ],
+        "object-shorthand": "off",
+        "one-var": "off",
+        "one-var-declaration-per-line": [
+            "error",
+            "initializations"
+        ],
+        "operator-assignment": "off",
+        "operator-linebreak": "error",
+        "padded-blocks": "off",
+        "padding-line-between-statements": "error",
+        "prefer-arrow-callback": "off",
+        "prefer-const": "off",
+        "prefer-destructuring": "off",
+        "prefer-named-capture-group": "error",
+        "prefer-numeric-literals": "error",
+        "prefer-object-spread": "off",
+        "prefer-promise-reject-errors": "error",
+        "prefer-reflect": "off",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "prefer-template": "off",
+        "quote-props": "off",
+        "quotes": "off",
+        "radix": [
+            "error",
+            "as-needed"
+        ],
+        "require-atomic-updates": "error",
+        "require-await": "error",
+        "require-jsdoc": "error",
+        "require-unicode-regexp": "off",
+        "rest-spread-spacing": "error",
+        "semi": "off",
+        "semi-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "semi-style": [
+            "error",
+            "last"
+        ],
+        "sort-keys": "off",
+        "sort-vars": "off",
+        "space-before-blocks": "error",
+        "space-before-function-paren": "off",
+        "space-in-parens": "off",
+        "space-infix-ops": "error",
+        "space-unary-ops": "off",
+        "spaced-comment": "off",
+        "strict": "error",
+        "switch-colon-spacing": "error",
+        "symbol-description": "error",
+        "template-curly-spacing": "error",
+        "template-tag-spacing": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "valid-jsdoc": "off",
+        "vars-on-top": "off",
+        "wrap-iife": "error",
+        "wrap-regex": "error",
+        "yield-star-spacing": "error",
+        "yoda": [
+            "error",
+            "never"
+        ]
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ index.html
 index.js
 package-lock.json
 yarn.lock
+
+# test artifacts
+test.mid.mid

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-destructuring": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
+    "eslint": "^5.16.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.17.3",
+    "eslint-plugin-node": "^9.1.0",
+    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-standard": "^4.0.0",
     "jsdoc": "^3.5.5",
     "minami": "^1.1.1",
     "mocha": "^5.2.0",
@@ -24,12 +30,13 @@
     "test": "test"
   },
   "scripts": {
+    "build": "mkdir -p build && rollup -c && npm run docs",
+    "docs": "./node_modules/.bin/jsdoc -r src README.md -d ./docs -t ./node_modules/minami",
+    "lint:js": "eslint 'src/**/**.js'",
+    "prepublishOnly": "npm test",
     "pretest": "npm run build",
     "test": "mocha",
-    "build": "mkdir -p build && rollup -c && npm run docs",
-    "watch": "watch 'npm run build' src",
-    "docs": "./node_modules/.bin/jsdoc -r src README.md -d ./docs -t ./node_modules/minami",
-    "prepublishOnly": "npm test"
+    "watch": "watch 'npm run build' src"
   },
   "repository": {
     "type": "git",

--- a/src/controller-change-event.js
+++ b/src/controller-change-event.js
@@ -1,4 +1,5 @@
 import {Constants} from './constants';
+import {Utils} from './utils.js';
 
 /**
  * Holds all data for a "controller change" MIDI event

--- a/src/note-events/note-event.js
+++ b/src/note-events/note-event.js
@@ -13,11 +13,11 @@ class NoteEvent {
 		// Set default fields
 		fields = Object.assign({
 			channel: 1,
-		    repeat: 1,
-		    sequential: false,
-		    startTick: null,
-		    velocity: 50,
-		    wait: 0,
+			repeat: 1,
+			sequential: false,
+			startTick: null,
+			velocity: 50,
+			wait: 0,
 		}, fields);
 
 		this.data 		= [];
@@ -162,7 +162,7 @@ class NoteEvent {
 		}
 
 		return this;
-	};
+	}
 }
 
 export {NoteEvent};

--- a/src/note-events/note-off-event.js
+++ b/src/note-events/note-off-event.js
@@ -11,7 +11,7 @@ class NoteOffEvent {
 		fields = Object.assign({
 			channel: 1,
 			noteOnTick: null,
-		    velocity: 50,
+			velocity: 50,
 		}, fields);
 
 		this.type 		= 'note-off';
@@ -24,7 +24,7 @@ class NoteOffEvent {
 		this.midiNumber = Utils.getPitch(this.pitch);
 		this.tick 		= null;
 		this.delta 		= Utils.getTickDuration(this.duration);
-		this.data 		= fields.data;	
+		this.data 		= fields.data;
 	}
 
 	/**

--- a/src/note-events/note-on-event.js
+++ b/src/note-events/note-on-event.js
@@ -11,8 +11,8 @@ class NoteOnEvent {
 		fields = Object.assign({
 			channel: 1,
 			startTick: null,
-		    velocity: 50,
-		    wait: 0,
+			velocity: 50,
+			wait: 0,
 		}, fields);
 
 		this.type 		= 'note-on';

--- a/src/track.js
+++ b/src/track.js
@@ -36,7 +36,7 @@ class Track {
 	 * Events without a specific startTick property are assumed to be added in order of how they should output.
 	 * Events with a specific startTick property are set aside for now will be merged in during build process.
 	 * @param {(NoteEvent|ProgramChangeEvent)} events - Event object or array of Event objects.
-	 * @param {function} mapFunction - Callback which can be used to apply specific properties to all events. 
+	 * @param {function} mapFunction - Callback which can be used to apply specific properties to all events.
 	 * @return {Track}
 	 */
 	addEvent(events, mapFunction) {
@@ -62,7 +62,7 @@ class Track {
 									event.velocity = Utils.convertVelocity(properties[j]);
 									break;
 							}
-						}		
+						}
 					}
 				}
 
@@ -109,7 +109,7 @@ class Track {
 		});
 
 		this.mergeExplicitTickEvents();
-		
+
 		this.size = Utils.numberToBytes(this.data.length, 4); // 4 bytes long
 		return this;
 	}
@@ -121,7 +121,7 @@ class Track {
 		this.explicitTickEvents.sort((a, b) => a.startTick - b.startTick);
 
 		// Now this.explicitTickEvents is in correct order, and so is this.events naturally.
-		// For each explicit tick event, splice it into the main list of events and 
+		// For each explicit tick event, splice it into the main list of events and
 		// adjust the delta on the following events so they still play normally.
 		this.explicitTickEvents.forEach((noteEvent) => {
 			// Convert NoteEvent to it's respective NoteOn/NoteOff events
@@ -157,7 +157,7 @@ class Track {
 	 * @return {Track}
 	 */
 	mergeSingleEvent(event) {
-		// Find index of existing event we need to follow with 
+		// Find index of existing event we need to follow with
 		var lastEventIndex = 0;
 
 		for (var i = 0; i < this.events.length; i++) {
@@ -219,7 +219,7 @@ class Track {
 
 	/**
 	 * Sets key signature.
-	 * @param {*} sf - 
+	 * @param {*} sf -
 	 * @param {*} mi -
 	 * @return {Track}
 	 */

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,14 +33,14 @@ class Utils {
 	}
 
 	/**
-     * Returns the correct MIDI number for the specified pitch.
-     * Uses Tonal Midi - https://github.com/danigb/tonal/tree/master/packages/midi
-     * @param {(string|number)} pitch - 'C#4' or midi note code
-     * @return {number}
-     */
-     static getPitch(pitch) {
-     	return toMidi(pitch);
-     }
+	 * Returns the correct MIDI number for the specified pitch.
+	 * Uses Tonal Midi - https://github.com/danigb/tonal/tree/master/packages/midi
+	 * @param {(string|number)} pitch - 'C#4' or midi note code
+	 * @return {number}
+	 */
+	static getPitch(pitch) {
+		return toMidi(pitch);
+	}
 
 	/**
 	 * Translates number of ticks to MIDI timestamp format, returning an array of
@@ -52,22 +52,22 @@ class Utils {
 	 * @return {array} - Bytes that form the MIDI time value
 	 */
 	static numberToVariableLength(ticks) {
-	    var buffer = ticks & 0x7F;
+		var buffer = ticks & 0x7F;
 
-	    while (ticks = ticks >> 7) {
-	        buffer <<= 8;
-	        buffer |= ((ticks & 0x7F) | 0x80);
-	    }
+		while (ticks = ticks >> 7) {
+			buffer <<= 8;
+			buffer |= ((ticks & 0x7F) | 0x80);
+		}
 
-	    var bList = [];
-	    while (true) {
-	        bList.push(buffer & 0xff);
+		var bList = [];
+		while (true) {
+			bList.push(buffer & 0xff);
 
-	        if (buffer & 0x80) buffer >>= 8
-	        else { break; }
-	    }
+			if (buffer & 0x80) buffer >>= 8
+			else { break; }
+		}
 
-	    return bList;
+		return bList;
 	}
 
 	/**
@@ -131,7 +131,7 @@ class Utils {
 		return hexArray;
 	}
 
-	/**	
+	/**
 	 * Converts value to array if needed.
 	 * @param {string} value
 	 * @return {array}
@@ -150,7 +150,7 @@ class Utils {
 		// Max passed value limited to 100
 		velocity = velocity > 100 ? 100 : velocity;
 		return Math.round(velocity / 100 * 127);
-	};
+	}
 
 	/**
 	 * Gets the total number of ticks of a specified duration.
@@ -231,7 +231,7 @@ class Utils {
 		}
 
 		throw duration + ' is not a valid duration.';
-	};
+	}
 }
 
 export {Utils};

--- a/src/vexflow.js
+++ b/src/vexflow.js
@@ -2,7 +2,7 @@ import {NoteEvent} from './note-events/note-event';
 import {Track} from './track';
 
 class VexFlow {
-	
+
 	constructor() {
 		// code...
 	}
@@ -32,7 +32,7 @@ class VexFlow {
 			}
 
 			track.addEvent(new NoteEvent({pitch: pitches, duration: this.convertDuration(tickable), wait: wait}));
-			
+
 			// reset wait
 			wait = 0;
 		});
@@ -47,7 +47,7 @@ class VexFlow {
 	 */
 	convertPitch(pitch) {
 		return pitch.replace('/', '');
-	} 
+	}
 
 
 	/**
@@ -67,7 +67,7 @@ class VexFlow {
 		}
 
 		return note.duration;
-	};
+	}
 }
 
 export {VexFlow};

--- a/src/writer.js
+++ b/src/writer.js
@@ -1,5 +1,4 @@
 import {HeaderChunk} from './header-chunk';
-import {Constants} from './constants';
 import {Utils} from './utils';
 
 /**
@@ -12,7 +11,7 @@ class Writer {
 		// Ensure track is an array
 		tracks = Utils.toArray(tracks);
 
-		this.data = [];		
+		this.data = [];
 		this.data.push(new HeaderChunk(tracks.length))
 
 		// For each track add final end of track event and build data
@@ -48,7 +47,7 @@ class Writer {
      * @return {string}
      */
     dataUri() {
-    	return 'data:audio/midi;base64,' + this.base64();
+		return 'data:audio/midi;base64,' + this.base64();
     }
 
 	/**
@@ -56,7 +55,7 @@ class Writer {
 	 * @return {string}
 	 */
     stdout() {
-    	return process.stdout.write(new Buffer(this.buildFile()));
+		return process.stdout.write(new Buffer(this.buildFile()));
     }
 
 	/**


### PR DESCRIPTION
- I have gotten used to working with a `.editorconfig` file to share settings across developers & editors, perhaps it will work for you? :)
- the eslint config was generated by eslint based on the existing code style, adding plugins that seemed to make sense to me (for details on the latter, please see the `package.json` changes)
- adds a test artifacts section to `.gitignore` (the MIDI file was generated as part of the build, which I assume should not be checked in. I did not include the accompanying fresh docs build in this PR though)
- `package.json`: alpha-sort npm scripts, adds eslint requirements
- `controller-change-event.js` `ControllerChangeEvent` seems unused at present? but added missing import eslint spotted
- `writer.js` one unused import eslint spotted

Apart from that, it's fixing mixed tab & spaces, trailing whitespace and "extra" semicolons eslint thought did not match the style of the rest of the codebase.

eslint now only moans about use of `var` and using a bitwise operator at the top of a loop, IIRC, but as these are more controversial I decided to leave them.