### PR TITLE
Add startTick to duration in NoteOffEvent instead of subtracting it

### DIFF
--- a/src/note-events/note-event.js
+++ b/src/note-events/note-event.js
@@ -105,7 +105,7 @@ class NoteEvent {
 							duration: this.duration,
 							velocity: this.velocity,
 							pitch: p,
-							tick: this.startTick !== null ? Utils.getTickDuration(this.duration) - this.startTick : null,
+							tick: this.startTick !== null ? Utils.getTickDuration(this.duration) + this.startTick : null,
 						});
 
 					} else {
@@ -116,7 +116,7 @@ class NoteEvent {
 							duration: 0,
 							velocity: this.velocity,
 							pitch: p,
-							tick: this.startTick !== null ? Utils.getTickDuration(this.duration) - this.startTick : null,
+							tick: this.startTick !== null ? Utils.getTickDuration(this.duration) + this.startTick : null,
 						});
 					}
 


### PR DESCRIPTION
First off, thanks for writing this library! It's saved me from having to learn and implement the MIDI file spec myself.

I feel like the NoteOffEvent `tick` property should be `startTick + duration`, not `-startTick + duration`. Is that correct or is there something I'm missing?