### PR TITLE
Vexflow conversion enhancements

### DIFF
--- a/src/vexflow.js
+++ b/src/vexflow.js
@@ -7,14 +7,14 @@ class VexFlow {
 	 * Support for converting VexFlow voice into MidiWriterJS track
 	 * @return MidiWriter.Track object
 	 */
-	trackFromVoice(voice) {
+	trackFromVoice(voice, options={addRenderedAccidentals: false}) {
 		const track = new Track();
 		let wait = [];
 
 		voice.tickables.forEach(tickable => {
 			if (tickable.noteType === 'n') {
 				track.addEvent(new NoteEvent({
-					pitch: tickable.keys.map(this.convertPitch),
+					pitch: tickable.keys.map((pitch, index) => this.convertPitch(pitch, index, tickable, options.addRenderedAccidentals)),
 					duration: this.convertDuration(tickable),
 					wait
 				}));
@@ -40,9 +40,31 @@ class VexFlow {
 	/**
 	 * Converts VexFlow pitch syntax to MidiWriterJS syntax
 	 * @param pitch string
+	 * @param index pitch index
+	 * @param note struct from Vexflow
+	 * @param addRenderedAccidentals adds Vexflow rendered accidentals
 	 */
-	convertPitch(pitch) {
-		return pitch.replace('/', '');
+	convertPitch(pitch, index, note, addRenderedAccidentals=false) {
+		// Splits note name from octave
+		const pitchParts = pitch.split('/');
+
+		// Retrieves accidentals from pitch
+		// Removes natural accidentals since they are not accepted in Tonal Midi
+		let accidentals = pitchParts[0].substring(1).replace('n', '');
+		
+		if (addRenderedAccidentals) {
+			note.getAccidentals()?.forEach(accidental => {
+				if (accidental.index === index) {
+					if (accidental.type === 'n') {
+						accidentals = '';
+					} else {
+						accidentals += accidental.type;
+					}
+				}
+			});
+		}
+
+		return pitchParts[0][0] + accidentals + pitchParts[1];
 	}
 
 	/**

--- a/src/vexflow.js
+++ b/src/vexflow.js
@@ -50,18 +50,25 @@ class VexFlow {
 	 * @param note struct from VexFlow
 	 */
 	convertDuration(note) {
-		switch (note.duration) {
+		return 'd'.repeat(note.dots) + this.convertBaseDuration(note.duration) + (note.tuplet ? 't' + note.tuplet.num_notes : '');
+	}
+
+	/**
+	 * Converts VexFlow base duration syntax to MidiWriterJS syntax
+	 * @param duration Vexflow duration
+	 * @returns MidiWriterJS duration
+	 */
+	convertBaseDuration(duration) {
+		switch (duration) {
 			case 'w':
 				return '1';
 			case 'h':
-				return note.isDotted() ? 'd2' : '2';
+				return '2';
 			case 'q':
-				return note.isDotted() ? 'd4' : '4';
-			case '8':
-				return note.isDotted() ? 'd8' : '8';
+				return '4';
+			default:
+				return duration;
 		}
-
-		return note.duration;
 	}
 }
 

--- a/test/vexflow.js
+++ b/test/vexflow.js
@@ -86,9 +86,24 @@ describe('MidiWriterJS', function() {
 
 		describe('#convertPitch()', function() {
 			it('converts pitch', function () {
-				const vexNote = 'pit/ch';
 				const vexFlow = new MidiWriter.VexFlow();
-				assert.strictEqual(vexFlow.convertPitch(vexNote), 'pitch');
+				const tickable = mockNote('n', 'h', ['c/4']);
+				assert.deepStrictEqual(tickable.keys.map((pitch, index) => vexFlow.convertPitch(pitch, index, tickable)), ['c4']);
+			});
+			it('converts multiple pitch', function() {
+				const vexFlow = new MidiWriter.VexFlow();
+				const tickable = mockNote('n', 'h', ['b/4', 'c/4']);
+				assert.deepStrictEqual(tickable.keys.map((pitch, index) => vexFlow.convertPitch(pitch, index, tickable)), ['b4', 'c4']);
+			});
+			it('converts accidentals pitch', function() {
+				const vexFlow = new MidiWriter.VexFlow();
+				const tickable = mockNote('n', 'h', ['b#/4', 'cb/4', 'dn/4']);
+				assert.deepStrictEqual(tickable.keys.map((pitch, index) => vexFlow.convertPitch(pitch, index, tickable)), ['b#4', 'cb4', 'd4']);
+			});
+			it('converts rendered accidentals pitch', function() {
+				const vexFlow = new MidiWriter.VexFlow();
+				const tickable = mockNote('n', 'h', ['b/4', 'c/4'], 0, null, [{index: 0, type: '#'}, {index: 1, type: 'b'}]);
+				assert.deepStrictEqual(tickable.keys.map((pitch, index) => vexFlow.convertPitch(pitch, index, tickable, true)), ['b#4', 'cb4']);
 			});
 		});
 

--- a/test/vexflow.js
+++ b/test/vexflow.js
@@ -8,13 +8,15 @@ const MidiWriter = require('..');
  * @param {[String]} keys
  * @param {boolean} isDotted
  */
-function mockNote(noteType='n', duration='8', keys=['c/4'], isDotted=false) {
+function mockNote(noteType='n', duration='8', keys=['c/4'], dots=0, tuplet=null, accidentals=null) {
 	const result = {
 		noteType,
 		duration,
 		keys,
-		isDotted() {
-			return isDotted;
+		dots,
+		tuplet,
+		getAccidentals() {
+			return accidentals;
 		}
 	};
 	return result;
@@ -104,19 +106,44 @@ describe('MidiWriterJS', function() {
 			});
 			it('converts dotted half, quarter and eighth durations', function () {
 				const vexFlow = new MidiWriter.VexFlow();
-				const tickable = mockNote('n', 'h', ['c4'], true);
+				const tickable = mockNote('n', 'h', ['c/4'], 1);
 				assert.strictEqual(vexFlow.convertDuration(tickable), 'd2');
 				tickable.duration = 'q'
 				assert.strictEqual(vexFlow.convertDuration(tickable), 'd4');
 				tickable.duration = '8'
 				assert.strictEqual(vexFlow.convertDuration(tickable), 'd8');
 			});
-			it('preserves numeric and other durations', function () {
+			it('converts multiple dotted durations', function() {
 				const vexFlow = new MidiWriter.VexFlow();
-				const tickable = mockNote('n', 99);
-				assert.strictEqual(vexFlow.convertDuration(tickable), 99);
-				tickable.duration = 'other'
-				assert.strictEqual(vexFlow.convertDuration(tickable), 'other');
+				const tickable = mockNote('n', 'h', ['c/4'], 2);
+				assert.strictEqual(vexFlow.convertDuration(tickable), 'dd2');
+				tickable.dots = 3
+				assert.strictEqual(vexFlow.convertDuration(tickable), 'ddd2');
+				tickable.dots = 4
+				assert.strictEqual(vexFlow.convertDuration(tickable), 'dddd2');
+			});
+			it('converts tuplet durations', function() {
+				const vexFlow = new MidiWriter.VexFlow();
+				const tickable = mockNote('n', 'h', ['c/4'], 0, {num_notes: 3});
+				assert.strictEqual(vexFlow.convertDuration(tickable), '2t3');
+				tickable.tuplet.num_notes = 5
+				assert.strictEqual(vexFlow.convertDuration(tickable), '2t5');
+				tickable.tuplet.num_notes = 7
+				assert.strictEqual(vexFlow.convertDuration(tickable), '2t7');
+			});
+			it('converts dotted tuplet durations', function() {
+				const vexFlow = new MidiWriter.VexFlow();
+				const tickable = mockNote('n', 'h', ['c/4'], 1, {num_notes: 3});
+				assert.strictEqual(vexFlow.convertDuration(tickable), 'd2t3');
+				tickable.tuplet.num_notes = 5
+				assert.strictEqual(vexFlow.convertDuration(tickable), 'd2t5');
+				tickable.dots = 2
+				assert.strictEqual(vexFlow.convertDuration(tickable), 'dd2t5');
+			});
+			it('returns other durations', function () {
+				const vexFlow = new MidiWriter.VexFlow();
+				const tickable = mockNote('n', '64', ['c/4']);	
+				assert.strictEqual(vexFlow.convertDuration(tickable), '64');
 			});
 		});
 	});


### PR DESCRIPTION
Added multiple dots and tupplet support for Vexflow conversion.
Also added an option to add Vexflow rendered accidentals to the pitch conversion. Decided to default that option to false since there are differences between the internal and the rendered data of a tickable and that may cause unintended results to people trusting only the internals for the output. I am open to any revision of this implementation.
Finally, I added some tests to cover these new cases.