### PR TITLE
Add channel support for program change

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,7 +25,6 @@ const Constants = {
 	META_KEY_SIGNATURE_ID	: 0x59,
 	META_END_OF_TRACK_ID	: [0x2F, 0x00],
 	CONTROLLER_CHANGE_STATUS: 0xB0, // includes channel number (0)
-	PROGRAM_CHANGE_STATUS	: 0xC0, // includes channel number (0)
 	PITCH_BEND_STATUS       : 0xE0, // includes channel number (0)
 };
 

--- a/src/meta-events/program-change-event.js
+++ b/src/meta-events/program-change-event.js
@@ -20,7 +20,7 @@ class ProgramChangeEvent {
 
 
 	/**
-	 * Gets the status code based on the selected channel. 0x9{0-F}
+	 * Gets the status code based on the selected channel. 0xC{0-F}
 	 * Program change status byte for channel 0 is 0xC0 (192)
 	 * 0 = Ch 1
 	 * @return {number}

--- a/src/meta-events/program-change-event.js
+++ b/src/meta-events/program-change-event.js
@@ -1,4 +1,3 @@
-import {Constants} from '../constants';
 import {Utils} from '../utils';
 
 /**

--- a/src/meta-events/program-change-event.js
+++ b/src/meta-events/program-change-event.js
@@ -9,14 +9,24 @@ import {Utils} from '../utils';
 class ProgramChangeEvent {
 	constructor(fields) {
 		// Set default fields
-		fields = Object.assign({
+		this.fields = Object.assign({
+			channel: 1,
 			delta: 0x00,
 		}, fields);
 
 		this.type = 'program';
 		// delta time defaults to 0.
-		this.data = Utils.numberToVariableLength(fields.delta).concat(Constants.PROGRAM_CHANGE_STATUS, fields.instrument);
+		this.data = Utils.numberToVariableLength(this.fields.delta).concat(this.getStatusByte(), this.fields.instrument);
 	}
+
+
+	/**
+	 * Gets the status code based on the selected channel. 0x9{0-F}
+	 * Program change status byte for channel 0 is 0xC0 (192)
+	 * 0 = Ch 1
+	 * @return {number}
+	 */
+	getStatusByte() {return 192 + this.fields.channel - 1}
 }
 
 export {ProgramChangeEvent};


### PR DESCRIPTION
When changing the program, it's necessary to use a different channel.  This exposes the `channel` property so that's possible.

```js
const track = new MidiWriter.Track();
track.addEvent(new MidiWriter.ProgramChangeEvent({instrument: 1, channel: 2}));
```

Closes #97 