### PR TITLE
Support manually adding EndTrackEvent with custom delta.

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -79,6 +79,12 @@ class Track {
 					event.buildData().events.forEach((e) => this.events.push(e));
 				}
 
+			} else if (event instanceof EndTrackEvent) {
+				// Only one EndTrackEvent is allowed, so remove
+				// any existing ones before adding.
+				this.removeEventsByType('end-track');
+				this.events.push(event);
+
 			} else {
 				this.events.push(event);
 			}
@@ -95,7 +101,11 @@ class Track {
 	buildData(options = {}) {
 		// Remove existing end track event and add one.
 		// This makes sure it's at the very end of the event list.
-		this.removeEventsByType('end-track').addEvent(new EndTrackEvent());
+
+		// If the last event isn't EndTrackEvent, then tack it onto the data.
+		if (!this.events.length || !(this.events[this.events.length - 1] instanceof EndTrackEvent)) {
+			this.addEvent(new EndTrackEvent);
+		}
 
 		// Reset
 		this.data = [];
@@ -170,8 +180,14 @@ class Track {
 	 * @return {Track}
 	 */
 	mergeSingleEvent(event) {
+		// There are no events yet, so just add it in.
+		if (!this.events.length) {
+			this.addEvent(event);
+			return;
+		}
+
 		// Find index of existing event we need to follow with
-		var lastEventIndex = 0;
+		let lastEventIndex;
 
 		for (let i = 0; i < this.events.length; i++) {
 			if (this.events[i].tick > event.tick) break;

--- a/src/track.js
+++ b/src/track.js
@@ -101,7 +101,7 @@ class Track {
 	buildData(options = {}) {
 		// If the last event isn't EndTrackEvent, then tack it onto the data.
 		if (!this.events.length || !(this.events[this.events.length - 1] instanceof EndTrackEvent)) {
-			this.addEvent(new EndTrackEvent);
+			this.addEvent(new EndTrackEvent());
 		}
 
 		// Reset

--- a/src/track.js
+++ b/src/track.js
@@ -99,9 +99,6 @@ class Track {
 	 * @return {Track}
 	 */
 	buildData(options = {}) {
-		// Remove existing end track event and add one.
-		// This makes sure it's at the very end of the event list.
-
 		// If the last event isn't EndTrackEvent, then tack it onto the data.
 		if (!this.events.length || !(this.events[this.events.length - 1] instanceof EndTrackEvent)) {
 			this.addEvent(new EndTrackEvent);

--- a/test/main.js
+++ b/test/main.js
@@ -214,6 +214,18 @@ describe('MidiWriterJS', function() {
 
 			assert.equal(JSON.stringify(bar2note, null, 2), JSON.stringify(bar2note2, null, 2));
 		})
+
+		it('should return specific base64 string when manually adding EndTrackEvent', function() {
+			const track = new MidiWriter.Track();
+
+			track.addEvent([
+				new MidiWriter.NoteEvent({pitch: ['C5', 'E5', 'G4'], duration: '4'}),
+				new MidiWriter.EndTrackEvent({delta: 5000}),
+			]);
+
+			const write = new MidiWriter.Writer(track);
+			assert.equal('TVRoZAAAAAYAAAABAIBNVHJrAAAAHgCQSEAAkExAAJBDQIEAgEhAAIBMQACAQ0CnCP8vAA==', write.base64());
+		})
 	});
 
 	describe('#Utils()', function() {


### PR DESCRIPTION
Usually `EndTrackEvent` is automatically added when the MIDI data is built.  With these changes, it can be explicitly added with a custom `delta` value.

```js
track.addEvent(new MidiWriter.EndTrackEvent({delta: 128}));
```

Closes #84 