### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "midi-writer-js",
   "version": "2.1.4",
   "description": "A library providing an API for generating MIDI files.",


### PR DESCRIPTION
"type": "module", will fix this error:

(node:5036) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
Uncaught SyntaxError C:\Users\clbal\OneDrive\Desktop\harmonize.js:3
import MidiWriter from "midi-writer-js";
^^^^^^