### PR TITLE
build: add dual package support for ESM and CommonJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "midi-writer-js",
-  "version": "3.0.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "midi-writer-js",
-      "version": "3.0.1",
+      "version": "3.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001434",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
       "dev": true,
       "funding": [
         {
@@ -2811,8 +2811,13 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/catharsis": {
       "version": "0.9.0",
@@ -8918,9 +8923,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001434",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
       "dev": true
     },
     "catharsis": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
   "name": "midi-writer-js",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A library providing an API for generating MIDI files.",
-  "main": "build/index.js",
+  "main": "build/index.cjs",
+  "module": "build/index.mjs",
   "types": "build/types/main.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/index.mjs",
+      "require": "./build/index.cjs",
+      "types": "./build/types/main.d.ts"
+    }
+  },
   "dependencies": {
     "@tonaljs/midi": "^4.9.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,42 +1,22 @@
 import typescript from '@rollup/plugin-typescript';
-import replace from "@rollup/plugin-replace";
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 
-export default [
-  {
-    input: "src/main.ts",
-    output: [
-      {
-        file: "browser/midiwriter.js",
-        format: "iife",
-        name: "MidiWriter",
-      },
-      {
-        file: "build/index.browser.js",
-        format: "es",
-        name: "MidiWriter",
-      },
-    ],
-    plugins: [
-      typescript(),
-      replace({
-        "process.browser": true,
-        "preventAssignment": true 
-      }),
-      nodeResolve(),
-    ],
-  },
-  {
-    input: 'src/main.ts',
-    output: {
-      file: 'build/index.js',
+export default {
+  input: 'src/main.ts',
+  output: [
+    {
+      file: 'build/index.cjs',
       format: 'cjs',
       exports: 'default',
     },
-    external: ['tonal-midi', 'fs'],
-    plugins: [
-      typescript(),
-      nodeResolve()
-    ]
-  }
-];
+    {
+      file: 'build/index.mjs',
+      format: 'es',
+    }
+  ],
+  external: ['tonal-midi', 'fs', '@tonaljs/midi'],
+  plugins: [
+    typescript(),
+    nodeResolve()
+  ]
+};

--- a/src/midi-events/note-on-event.ts
+++ b/src/midi-events/note-on-event.ts
@@ -1,5 +1,5 @@
-import {MidiEvent} from './midi-event';
-import {Utils} from '../utils';
+import { MidiEvent } from './midi-event';
+import { Utils } from '../utils';
 
 /**
  * Holds all data for a "note on" MIDI event
@@ -12,22 +12,22 @@ class NoteOnEvent implements MidiEvent {
 	delta: number;
 	status: 0x90;
 	name: string;
-	pitch: string|string[]|number|number[];
+	pitch: string | number;
 	velocity: number;
-	wait: string|number;
+	wait: string | number;
 	tick: number;
 	deltaWithPrecisionCorrection: number;
 
-	constructor(fields: { channel?: number; wait?: string|number; velocity?: number; pitch?: string|string[]|number|number[]; tick?: number; data?: number[]; delta?: number }) {
-		this.name 		= 'NoteOnEvent';
-		this.channel 	= fields.channel || 1;
-		this.pitch 		= fields.pitch;
-		this.wait 		= fields.wait || 0;
-		this.velocity 	= fields.velocity || 50;
+	constructor(fields: { channel?: number; wait?: string | number; velocity?: number; pitch?: string | number; tick?: number; data?: number[]; delta?: number }) {
+		this.name = 'NoteOnEvent';
+		this.channel = fields.channel || 1;
+		this.pitch = fields.pitch;
+		this.wait = fields.wait || 0;
+		this.velocity = fields.velocity || 50;
 
-		this.tick 		= fields.tick || null;
-		this.delta 		= null;
-		this.data 		= fields.data;
+		this.tick = fields.tick || null;
+		this.delta = null;
+		this.data = fields.data;
 		this.status = 0x90;
 	}
 
@@ -36,7 +36,7 @@ class NoteOnEvent implements MidiEvent {
 	 * @param {Track} track - parent track
 	 * @return {NoteOnEvent}
 	 */
-	buildData(track, precisionDelta, options: {middleC?: string} = {}) {
+	buildData(track, precisionDelta, options: { middleC?: string } = {}) {
 		this.data = [];
 
 		// Explicitly defined startTick event
@@ -56,14 +56,14 @@ class NoteOnEvent implements MidiEvent {
 		this.deltaWithPrecisionCorrection = Utils.getRoundedIfClose(this.delta - precisionDelta);
 
 		this.data = Utils.numberToVariableLength(this.deltaWithPrecisionCorrection)
-					.concat(
-						this.status | this.channel - 1,
-							Utils.getPitch(this.pitch, options.middleC),
-							Utils.convertVelocity(this.velocity)
-					);
+			.concat(
+				this.status | this.channel - 1,
+				Utils.getPitch(this.pitch, options.middleC),
+				Utils.convertVelocity(this.velocity)
+			);
 
 		return this;
 	}
 }
 
-export {NoteOnEvent};
+export { NoteOnEvent };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import {Constants} from './constants';
-import {toMidi} from '@tonaljs/midi';
+import { Constants } from './constants';
+import { toMidi } from '@tonaljs/midi';
 
 /**
  * Static utility functions used throughout the library.
@@ -40,7 +40,7 @@ class Utils {
 	 * @param {string} middleC
 	 * @return {number}
 	 */
-	static getPitch(pitch: any, middleC = 'C4'): number {
+	static getPitch(pitch: string | number, middleC: string | number = 'C4'): number {
 		return 60 - toMidi(middleC) + toMidi(pitch);
 	}
 
@@ -241,7 +241,7 @@ class Utils {
 				// how much faster or slower is this note compared to a quarter?
 				const ratio = base / 4;
 				let durationInQuarters = 1 / ratio;
-				const {dotted, tuplet} = match.groups;
+				const { dotted, tuplet } = match.groups;
 				if (dotted) {
 					const thisManyDots = dotted.length;
 					const divisor = Math.pow(2, thisManyDots);
@@ -260,4 +260,4 @@ class Utils {
 	}
 }
 
-export {Utils};
+export { Utils };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,13 @@
 {
-    "compilerOptions": {
-        "lib": ["esnext", "dom"],
-        "declaration": true,
-        "declarationDir": "./types"
-    }
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "declaration": true,
+    "declarationDir": "./types"
+  }
 }


### PR DESCRIPTION
- Update package.json with dual exports configuration (ESM/CJS)
- Simplify rollup config to output both module formats
- Remove browser-specific build configuration
- Update TypeScript config with ES2018 target and ESNext module
- Standardize code formatting (spacing in imports/types)
- Bump version to 3.1.2

This change enables the package to be consumed by both ESM and CommonJS projects through conditional exports, improving compatibility across different module systems.